### PR TITLE
docs: add command-line usage instructions and examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ You can run `novel-cli help` to view help information
 - `help`: Print this message or the help of the given subcommand(s).
   ### Options
     - `-v, --verbose`: Use verbose output. This option provides more detailed output.
-    - `-q, --quiet`: Do not print logs (default: false). This option suppresses logging output.
+    - `-q, --quiet`: Do not print logs (default: **false**). This option suppresses logging output.
     - `-h, --help`: Print help. This option displays the help information.
     - `-V, --version`: Print version. This option prints the version information.
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ You can run `novel-cli help` to view help information
   ```shell
   novel-cli download <bookid> --source <app-source> --format <output-format>
   ```
+- **Search for a novel from source**
+  ```shell
+    novel-cli search --source <SOURCE> <KEYWORD>
+    ```
 
 ### Commands
 

--- a/README.md
+++ b/README.md
@@ -38,8 +38,40 @@ The **novel-cli build** subcommand requires [pandoc](https://github.com/jgm/pand
 The **novel-cli real-cugan** subcommand requires [realcugan-ncnn-vulkan](https://github.com/nihui/realcugan-ncnn-vulkan)
 
 ## Usage
+ 
 
-You can run **novel-cli help** to view help information
+You can run `novel-cli help` to view help information
+
+### Examples
+- **The basic format of the command is:**
+  ```shell
+  novel-cli [OPTIONS] <COMMAND> [COMMAND-OPTIONS] [ARGUMENTS]
+  ````
+- **Download a novel from source in format**
+  ```shell 
+  novel-cli download <bookid> --source <app-source> --format <output-format>
+  ```
+   
+### Commands
+
+- `download`: Download novels from various sources.
+- `search`: Search for novels on various sources.
+- `info`: Print information about a novel on various sources.
+- `favorites`: Show saved favorite novels on various sources.
+- `transform`: Convert markdown files to pandoc style.
+- `check`: Check the format and content of pandoc style markdown files.
+- `build`: Build a novel from pandoc style markdown files or an mdBook folder.
+- `zip`: Compress an epub folder.
+- `unzip`: Decompress an epub file.
+- `real-cugan`: Run the realcugan-ncnn-vulkan program.
+- `update`: Check for updates, download files from GitHub, and replace them.
+- `completions`: Generate shell completions to standard output.
+- `help`: Print this message or the help of the given subcommand(s).
+  ### Options
+    - `-v, --verbose`: Use verbose output. This option provides more detailed output.
+    - `-q, --quiet`: Do not print logs (default: false). This option suppresses logging output.
+    - `-h, --help`: Print help. This option displays the help information.
+    - `-V, --version`: Print version. This option prints the version information.
 
 ## Contributing
 
@@ -47,4 +79,5 @@ You should read [CONTRIBUTING](https://github.com/novel-rs/cli/blob/main/CONTRIB
 
 ## License
 
-All the code in this repository is released under **[Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0)** and **[MIT license](https://opensource.org/licenses/MIT)**
+All the code in this repository is released under **[Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0)**
+and **[MIT license](https://opensource.org/licenses/MIT)**


### PR DESCRIPTION
This commit updates the README file to include detailed instructions on how to use the program's command-line interface. The new section includes information about available options and their respective functions, as well as several example commands for common use cases.